### PR TITLE
Use workspace to detect changes

### DIFF
--- a/lib/esbonio/esbonio/lsp/__init__.py
+++ b/lib/esbonio/esbonio/lsp/__init__.py
@@ -173,6 +173,11 @@ def _configure_lsp_methods(server: RstLanguageServer) -> RstLanguageServer:
 
     @server.feature(TEXT_DOCUMENT_DID_SAVE)
     def on_save(ls: RstLanguageServer, params: DidSaveTextDocumentParams):
+
+        # Keep track of the version for unsaved detection.
+        doc = ls.workspace.get_document(params.text_document.uri)
+        doc.last_saved_version = doc.version
+
         ls.save(params)
 
         for feature in ls._features.values():


### PR DESCRIPTION
I found I couldn't quite put into words alone my response to [this comment](https://github.com/swyddfa/esbonio/pull/490#discussion_r1021264524) so I've made a few changes, let me know your thoughts :smile: 

Here's a quick summary and some context.
- Thanks to the LSP spec, each document in the workspace carries a version number that the client bumps each time it sends a `textDocument/didChange` request. This tweaks esbonio's `didSave` handler to record the version of the document each time it's saved
- In `cb_env_before_read_docs` the last saved version for each document is compared against its current one with the document being added to the list to build if unsaved changes are detected.
- In `cb_source_read` the contents are unconditionally overridden with the contents of the workspace, ensuring the latest content is passed to Sphinx.

As a consequence
- The client no longer has to worry about unsaved vs saved files and the `esbonio.server.sphinx.build.unsaved.file` can become a generic `esbonio.server.build` command.
- This generic build command could optionally accept a list of files to build if the client wished to restrict the number of rebuilt files, but the filepaths would no longer be required.
- More than one unsaved file would be supported. - The use case I'm thinking of here is that I could be editing `fileA.rst`, switch to `fileB.rst` and label a section before switching back to `fileA.rst` to reference it. In this scenario the link would render correctly in the preview as the unsaved content for both files would be passed to Sphinx.

This code is far from perfect (I've already spotted a bug where you have to save a file at least once for the change detection to work) but hopefully it's enough to give some context to my comments in the original thread :smile: 